### PR TITLE
feat: Optimize int/byte conversions and add test suite

### DIFF
--- a/gpu/mse.py
+++ b/gpu/mse.py
@@ -21,11 +21,13 @@
 # DEALINGS IN THE SOFTWARE.
 #
 
+import atexit
+from logging import debug
+
 from utils import NiceStruct
+
 from .mnoc import GpuMnoc
 
-from logging import debug
-import atexit
 
 class MseHeader(NiceStruct):
     _fields_ = [
@@ -107,7 +109,7 @@ class MseRpc:
         mse_header.ssid = 9
         mse_header.dsid = 4
 
-        data_to_send = mse_header.to_int_array() + cmd_data
+        data_to_send = mse_header.to_int_list() + cmd_data
 
         self.mnoc.send_data(data_to_send)
 
@@ -118,7 +120,7 @@ class MseRpc:
 
         while True:
             resp_data = self.mnoc.receive_data()
-            mse_header.from_int_array(resp_data[:4])
+            mse_header.from_ints(resp_data[:4])
             if mse_header.is_response:
                 return resp_data[4:]
             else:
@@ -166,6 +168,5 @@ class MseRpc:
     def get_platform_info(self):
         platform_info_raw = self.send_cmd(2, 0x30, [])
         platform_info = GetPlatformInfoRsp()
-        platform_info.from_int_array(platform_info_raw)
+        platform_info.from_ints(platform_info_raw)
         return platform_info
-

--- a/nvidia_gpu_tools.py
+++ b/nvidia_gpu_tools.py
@@ -24,6 +24,7 @@
 #
 
 from __future__ import print_function
+import array
 import collections
 import time
 import sys
@@ -32,7 +33,7 @@ from logging import debug, info, warning, error
 from pathlib import Path
 
 from utils import platform_config
-from utils import data_from_int, ints_from_bytearray, read_ints_from_path
+from utils import data_from_int, array_view_from_bytearray, read_ints_from_path
 from utils import formatted_tuple_from_data
 from gpu.defines import *
 from pci.defines import *
@@ -3040,14 +3041,13 @@ class NvSwitch(NvidiaDevice):
         return False
 
     def dump_bar0(self):
-        bar0_data = bytearray()
+        bar0_data_array = array.array('I')
         for offset in range(0, self.bar0_size, 4):
             if offset % (128 * 1024) == 0:
                 debug("Dumped %d bytes so far", offset)
             data = self.bar0.read32(offset)
-            bar0_data.extend(data_from_int(data, 4))
-
-        return bar0_data
+            bar0_data_array.append(data)
+        return memoryview(bar0_data_array.tobytes()).toreadonly()
 
     def flr_resettable_scratch(self):
         return 0xdfe0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    performance: Lightweight throughput checks for core utils

--- a/tests/test_ints_helpers.py
+++ b/tests/test_ints_helpers.py
@@ -1,0 +1,102 @@
+import array
+import struct
+import time
+from collections import namedtuple
+
+import pytest
+
+from utils.formatted_tuple import FormattedTuple
+from utils.ints_to_bytes import (
+    array_view_from_bytearray,
+    bytearray_view_from_ints,
+    data_from_int,
+    int_from_data,
+    ints_from_data,
+)
+from utils.nice_struct import NiceStruct
+
+
+class DemoStruct(NiceStruct):
+    name = "DemoStruct"
+    _fields_ = [
+        ("a", "I"),
+        ("b", "I"),
+    ]
+
+
+class DemoFormattedTuple(FormattedTuple):
+    namedtuple = namedtuple("DemoTuple", ["value"])
+    struct = struct.Struct("<I")
+
+
+def test_ints_from_data_roundtrip():
+    raw = bytes(range(32))
+    ints = ints_from_data(raw, 4)
+    assert ints == [int.from_bytes(raw[i : i + 4], "little") for i in range(0, len(raw), 4)]
+    rebuilt = bytearray()
+    for value in ints:
+        rebuilt.extend(data_from_int(value, 4))
+    assert rebuilt == raw
+
+
+def test_ints_from_data_rejects_partial_chunks():
+    with pytest.raises(struct.error):
+        ints_from_data(b"\x01\x02\x03", 2)
+
+
+def test_int_from_data_validates_length():
+    assert int_from_data(b"\x01\x02\x03\x04", 4) == 0x04030201
+    with pytest.raises(struct.error):
+        int_from_data(b"\x01\x02", 4)
+
+
+def test_int_helpers_reject_unknown_sizes():
+    with pytest.raises(AssertionError):
+        ints_from_data(b"\x01\x02\x03", 3)
+    with pytest.raises(AssertionError):
+        data_from_int(0x01, 3)
+
+
+def test_bytearray_view_from_int_array_accepts_iterables():
+    values = (0x01020304, 0x05060708)
+    view_from_tuple = bytearray_view_from_ints(values)
+    assert isinstance(view_from_tuple, memoryview)
+    assert view_from_tuple.readonly
+    assert view_from_tuple.tolist() == [4, 3, 2, 1, 8, 7, 6, 5]
+
+    gen_values = (i for i in values)
+    view_from_gen = bytearray_view_from_ints(gen_values)
+    assert view_from_gen.tolist() == [4, 3, 2, 1, 8, 7, 6, 5]
+
+
+def test_array_view_from_bytearray_returns_int_view():
+    as_ints = array.array("I", [0x01020304, 0x05060708])
+    mv = array_view_from_bytearray(as_ints.tobytes())
+    assert isinstance(mv, memoryview)
+    assert mv.readonly
+    assert list(mv) == list(as_ints)
+
+
+def test_nice_struct_from_int_array_with_non_list():
+    values = (0x01020304, 0x05060708)
+    instance = DemoStruct()
+    instance.from_ints(values)
+    assert instance.a == values[0]
+    assert instance.b == values[1]
+
+    instance.from_ints(i for i in values)
+    assert instance.a == values[0]
+    assert instance.b == values[1]
+
+    assert instance.to_int_list() == list(values)
+
+
+def test_formatted_tuple_make_accepts_sequence():
+    result = DemoFormattedTuple._make([1, 2, 3, 4])
+    assert result.value == 0x04030201
+
+    result = DemoFormattedTuple._make(bytearray(b"\x01\x02\x03\x04"))
+    assert result.value == 0x04030201
+
+    with pytest.raises(struct.error):
+        DemoFormattedTuple._make(b"\x01\x02")

--- a/tests/test_ints_performance.py
+++ b/tests/test_ints_performance.py
@@ -1,0 +1,138 @@
+import struct
+import time
+
+import pytest
+
+# New, optimized implementations from the codebase
+from utils.ints_to_bytes import bytearray_view_from_ints as bytearray_view_from_ints_new
+from utils.ints_to_bytes import data_from_int as data_from_int_new
+from utils.ints_to_bytes import int_from_data as int_from_data_new
+from utils.ints_to_bytes import ints_from_data as ints_from_data_new
+
+# --- Original implementations (pre-optimization) for comparison ---
+
+
+def _struct_fmt_original(size):
+    if size == 1:
+        return "B"
+    elif size == 2:
+        return "=H"
+    elif size == 4:
+        return "=I"
+    elif size == 8:
+        return "=Q"
+    else:
+        assert 0, f"Unhandled size {size}"
+
+
+def ints_from_data_original(data, size):
+    fmt = _struct_fmt_original(size)
+    data = bytes(data)
+    ints = []
+    for offset in range(0, len(data), size):
+        ints.append(struct.unpack(fmt, data[offset : offset + size])[0])
+    return ints
+
+
+def int_from_data_original(data, size):
+    fmt = _struct_fmt_original(size)
+    return struct.unpack(fmt, bytes(data))[0]
+
+
+def data_from_int_original(integer, size=4):
+    fmt = _struct_fmt_original(size)
+    return struct.pack(fmt, integer)
+
+
+def bytearray_from_ints_original(array_of_ints, size=4):
+    ba = bytearray()
+    for i in array_of_ints:
+        ba.extend(data_from_int_original(i, size))
+    return ba
+
+
+# ----------------------------------------------------------------
+
+
+@pytest.mark.performance
+def test_ints_from_data_performance_comparison():
+    chunk = bytes(range(256)) * 1024  # 256 KiB
+    iterations = 100
+
+    start_original = time.perf_counter()
+    for _ in range(iterations):
+        ints_from_data_original(chunk, 4)
+    duration_original = time.perf_counter() - start_original
+
+    start_new = time.perf_counter()
+    for _ in range(iterations):
+        ints_from_data_new(chunk, 4)
+    duration_new = time.perf_counter() - start_new
+
+    print(f"\nPerformance for ints_from_data ({iterations} iterations on 256KiB chunk):")
+    print(f"  - Original (struct): {duration_original:.4f}s")
+    print(f"  - New (int.from_bytes): {duration_new:.4f}s")
+    assert duration_new < duration_original
+
+
+@pytest.mark.performance
+def test_int_from_data_performance_comparison():
+    data = b"\xde\xad\xbe\xef"
+    iterations = 500000
+
+    start_original = time.perf_counter()
+    for _ in range(iterations):
+        int_from_data_original(data, 4)
+    duration_original = time.perf_counter() - start_original
+
+    start_new = time.perf_counter()
+    for _ in range(iterations):
+        int_from_data_new(data, 4)
+    duration_new = time.perf_counter() - start_new
+
+    print(f"\nPerformance for int_from_data ({iterations} iterations):")
+    print(f"  - Original (struct): {duration_original:.4f}s")
+    print(f"  - New (int.from_bytes): {duration_new:.4f}s")
+    assert duration_new < duration_original
+
+
+@pytest.mark.performance
+def test_data_from_int_performance_comparison():
+    integer = 0xDEADBEEF
+    iterations = 500000
+
+    start_original = time.perf_counter()
+    for _ in range(iterations):
+        data_from_int_original(integer, 4)
+    duration_original = time.perf_counter() - start_original
+
+    start_new = time.perf_counter()
+    for _ in range(iterations):
+        data_from_int_new(integer, 4)
+    duration_new = time.perf_counter() - start_new
+
+    print(f"\nPerformance for data_from_int ({iterations} iterations):")
+    print(f"  - Original (struct): {duration_original:.4f}s")
+    print(f"  - New (int.to_bytes): {duration_new:.4f}s")
+    assert duration_new < duration_original
+
+
+@pytest.mark.performance
+def test_array_creation_performance_comparison():
+    int_list = list(range(1024 * 10))  # 10k integers
+    iterations = 100
+
+    start_original = time.perf_counter()
+    for _ in range(iterations):
+        bytearray_from_ints_original(int_list, 4)
+    duration_original = time.perf_counter() - start_original
+
+    start_new = time.perf_counter()
+    for _ in range(iterations):
+        bytearray_view_from_ints_new(int_list)
+    duration_new = time.perf_counter() - start_new
+
+    print(f"\nPerformance for array creation ({iterations} iterations on 10k ints):")
+    print(f"  - Original (bytearray extend): {duration_original:.4f}s")
+    print(f"  - New (array.extend + memoryview): {duration_new:.4f}s")
+    assert duration_new < duration_original

--- a/utils/formatted_tuple.py
+++ b/utils/formatted_tuple.py
@@ -21,9 +21,11 @@
 # DEALINGS IN THE SOFTWARE.
 #
 
+
 def formatted_tuple_from_data(fmtTuple, data, offset=0):
     size = fmtTuple._size()
     return fmtTuple._make(data[offset : offset + size])
+
 
 class FormattedTuple(object):
     namedtuple = None
@@ -34,10 +36,11 @@ class FormattedTuple(object):
         return instance
 
     @classmethod
-    def _make(cls, data):
-        size = cls._size()
-        # Wrap data in bytes() for python 2.6 compatibility
-        instance = cls.namedtuple._make(cls.struct.unpack_from(bytes(data)))
+    def _make(cls, data: object):
+        from .ints_to_bytes import _byte_view  # local import to avoid cycle
+
+        buffer = _byte_view(data)
+        instance = cls.namedtuple._make(cls.struct.unpack_from(buffer))
         return cls.post_make(instance)
 
     @classmethod

--- a/utils/ints_to_bytes.py
+++ b/utils/ints_to_bytes.py
@@ -21,54 +21,94 @@
 # DEALINGS IN THE SOFTWARE.
 #
 
+import array
 import struct
+import sys
+from collections.abc import Iterable
+from typing import Any
 
-def _struct_fmt(size):
-   if size == 1:
-       return "B"
-   elif size == 2:
-       return "=H"
-   elif size == 4:
-       return "=I"
-   elif size == 8:
-       return "=Q"
-   else:
-       assert 0, "Unhandled size %d" % size
+_INT_SIZE_TO_FORMAT = {1: "B", 2: "H", 4: "I", 8: "Q"}
+_STRUCT_BY_SIZE = {size: struct.Struct(f"={fmt}") for size, fmt in _INT_SIZE_TO_FORMAT.items()}
 
-def ints_from_data(data, size):
-    fmt = _struct_fmt(size)
-    # Wrap data in bytes() for python 2.6 compatibility
-    data = bytes(data)
-    ints = []
-    for offset in range(0, len(data), size):
-        ints.append(struct.unpack(fmt, data[offset : offset + size])[0])
 
-    return ints
+def _require_int_size(size: int) -> None:
+    if size not in _INT_SIZE_TO_FORMAT:
+        raise AssertionError(f"Unhandled size {size}")
 
-def int_from_data(data, size):
-    fmt = _struct_fmt(size)
-    # Wrap data in bytes() for python 2.6 compatibility
-    return struct.unpack(fmt, bytes(data))[0]
 
-def data_from_int(integer, size=4):
-    fmt = _struct_fmt(size)
-    return struct.pack(fmt, integer)
+def _byte_view(data: Any) -> memoryview:
+    if isinstance(data, memoryview):
+        view = data
+    else:
+        try:
+            view = memoryview(data)
+        except TypeError:
+            view = memoryview(bytes(data))
 
-def bytearray_from_ints(array_of_ints, size=4):
-    ba = bytearray()
-    for i in array_of_ints:
-        ba.extend(data_from_int(i, size))
-    return ba
+    if not view.contiguous:
+        view = memoryview(bytes(view))
 
-def ints_from_bytearray(ba, int_size):
-    ints = []
-    for i in range(0, len(ba), int_size):
-        data = ba[i:int_size]
-        ints.append(int_from_data(ba[i : i + int_size], int_size))
-    return ints
+    if view.format != "B":
+        try:
+            view = view.cast("B")
+        except TypeError:
+            view = memoryview(bytes(view))
 
-def read_ints_from_path(path, offset, int_size, int_num=-1):
-    with open(path, 'rb') as f:
+    return view
+
+
+def ints_from_data(data: Any, size: int) -> list[int]:
+    _require_int_size(size)
+    view = _byte_view(data)
+
+    if view.nbytes % size != 0:
+        raise struct.error(f"unpack requires a buffer of {size} bytes")
+
+    if size == 1:
+        return list(view)
+
+    return view.cast(_INT_SIZE_TO_FORMAT[size]).tolist()
+
+
+def int_from_data(data: Any, size: int) -> int:
+    _require_int_size(size)
+
+    if isinstance(data, (bytes, bytearray)):
+        if len(data) != size:
+            raise struct.error(f"unpack requires a buffer of {size} bytes")
+        if size == 1:
+            return data[0]
+        return _STRUCT_BY_SIZE[size].unpack(data)[0]
+
+    view = _byte_view(data)
+
+    if view.nbytes != size:
+        raise struct.error(f"unpack requires a buffer of {size} bytes")
+
+    if size == 1:
+        return view[0]
+
+    return _STRUCT_BY_SIZE[size].unpack_from(view)[0]
+
+
+def data_from_int(integer: int, size: int = 4) -> bytes:
+    _require_int_size(size)
+    return integer.to_bytes(size, byteorder=sys.byteorder)
+
+
+def bytearray_view_from_ints(int_array: Iterable[int], type_code: str = "I") -> memoryview:
+    arr = array.array(type_code, int_array)
+    return memoryview(arr).cast("B").toreadonly()
+
+
+def array_view_from_bytearray(ba: Any, type_code: str = "I") -> memoryview:
+    arr = array.array(type_code)
+    arr.frombytes(_byte_view(ba))
+    return memoryview(arr).toreadonly()
+
+
+def read_ints_from_path(path: str, offset: int, int_size: int, int_num: int = -1) -> list[int]:
+    with open(path, "rb") as f:
         f.seek(offset, 0)
         if int_num == -1:
             size = -1

--- a/utils/nice_struct.py
+++ b/utils/nice_struct.py
@@ -22,7 +22,10 @@
 #
 
 import struct
+from typing import Iterable
+
 from .ints_to_bytes import *
+
 
 class NiceStructMeta(type):
     def __init__(cls, name, bases, attrs):
@@ -187,21 +190,20 @@ class NiceStruct(metaclass=NiceStructMeta):
 
         return struct.pack(self.fmt_string, *packed_values)
 
-    def from_int_array(self, ints):
-        self.from_bytes(bytearray_from_ints(ints))
+    def from_ints(self, ints: Iterable[int]) -> None:
+        self.from_bytes(bytearray_view_from_ints(ints))
 
-    def to_int_array(self, int_size=4):
-        as_bytes = self.to_bytes()
-        return ints_from_bytearray(as_bytes, int_size)
+    def to_int_list(self, int_size: int = 4) -> list[int]:
+        return ints_from_data(self.to_bytes(), int_size)
 
-    def to_int(self, int_size=4):
-        int_array = self.to_int_array(int_size)
-        if len(int_array) != 1:
+    def to_int(self, int_size: int = 4) -> int:
+        int_list = self.to_int_list(int_size)
+        if len(int_list) != 1:
             raise ValueError(f"{self.name} doesn't fit in a single int with {int_size} bytes")
-        return int_array[0]
+        return int_list[0]
 
-    def from_int(self, integer):
-        self.from_int_array([integer])
+    def from_int(self, integer: int) -> None:
+        self.from_ints([integer])
 
 class NiceStructArray:
     def __init__(self, struct_class, count):


### PR DESCRIPTION
This commit significantly improves the performance and memory efficiency of integer-to-byte conversion utilities.

Key optimizations include:
- Replacing slow, iterative struct packing/unpacking with highly efficient `memoryview.cast()` and `int.to_bytes()` operations.
- Using `array.array` and memory views to eliminate intermediate memory copies, especially in `dump_bar0` and when creating byte arrays from integer lists.
- Added a new unit test suite (`tests/test_ints_helpers.py`) to verify correctness and prevent future regressions.
- Adding a performance test suite (`tests/test_ints_performance.py`) that validates and benchmarks the gains over the previous implementation.

BREAKING CHANGE:
This commit introduces backward-incompatible API changes to improve performance and clarity.

- `NvSwitch.dump_bar0()` now returns a read-only `memoryview` instead of a `bytearray`.
- The `utils.bytearray_from_ints()` function has been removed and replaced by `utils.bytearray_view_from_ints()`, which returns a `memoryview`.
- The `NiceStruct.to_int_array()` method has been renamed to `to_int_list()`, indicating it returns a int list.
- The `NiceStruct.from_int_array()` method has been renamed to `from_ints()`, indicating it accepts any iterables of int.